### PR TITLE
add validator to check port range when adding the server

### DIFF
--- a/src/app/assets/js/home/server.js
+++ b/src/app/assets/js/home/server.js
@@ -119,6 +119,11 @@ function saveServer() {
 		valid = false;
 	}
 
+	if (port.val() < 0 || port.val() >= 65536) {
+		port.parent().parent().addClass('has-warning');
+		valid = false;
+	}
+
 	var data = {
 		_csrf: $('#_csrf').val(),
 		name: name.val(),

--- a/src/app/views/home/servers.jade
+++ b/src/app/views/home/servers.jade
@@ -56,7 +56,7 @@ block content
 							.form-group
 								label.col-sm-2.control-label(for="port") Port
 								.col-sm-10
-									input.form-control#port(type="text", placeholder="11300")
+									input.form-control#port(type="text", placeholder="11300, port should be >= 0 and < 65536")
 					.modal-footer
 						span.preloader
 							img(src="/assets/images/preloader.gif")


### PR DESCRIPTION
@BossaGroove 
 **Bug Description:**
doesn't check the port range in front end, so when the wrong config saved to the `~/.beanmaster/config.json`, typing `beanmaster` to start server will always throw error. need to delete or modify the config.json manually so as to solve this problem.

![image](https://cloud.githubusercontent.com/assets/842218/15267195/8681a27a-19ed-11e6-9a9a-6f09098fc8e6.png)